### PR TITLE
chore: GitHub ActionsのバージョンをSHA付きに固定

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -16,10 +16,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Assign PR to all commit authors
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const autoAssign = require('./.github/scripts/auto-assign.js');


### PR DESCRIPTION
## 変更内容
GitHub Actionsで使用しているアクションのバージョンを特定のSHAにピン留めしました。

## 理由
GitHubの公式ドキュメントで推奨されているセキュリティベストプラクティス

ref: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions