### PR TITLE
chore: pnpmストアディレクトリをfrontend配下に設定

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# pnpm
+.pnpm-store

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+store-dir=.pnpm-store


### PR DESCRIPTION
## What
- `frontend/.npmrc`を追加し、pnpmストアディレクトリを`.pnpm-store`に指定
- `frontend/.gitignore`に`.pnpm-store`を追加

## Why
pnpmのストアディレクトリがプロジェクトルートに作成されるのを防ぐため、frontendディレクトリ配下に保存するよう設定しました。

Closes #13 