### PR TITLE
feat: domain層整備

### DIFF
--- a/backend/internal/domain/draw/draw.go
+++ b/backend/internal/domain/draw/draw.go
@@ -1,0 +1,61 @@
+package draw
+
+import (
+	"errors"
+
+	"backend/internal/domain/post"
+)
+
+var (
+	// ErrEmptyResult は結果が空の場合に返される。
+	ErrEmptyResult = errors.New("draw: result is empty")
+	// ErrEmptyPostID は Post ID が空の場合に返される。
+	ErrEmptyPostID = errors.New("draw: post id is empty")
+	// ErrNilPost は nil の Post を受け取った際に返される。
+	ErrNilPost = errors.New("draw: nil post supplied")
+	// ErrPostNotReady は ready でない Post から Draw を生成しようとした際に返される。
+	ErrPostNotReady = errors.New("draw: post is not ready")
+)
+
+// Draw はおみくじ結果を表す。
+type Draw struct {
+	postID string
+	result string
+}
+
+// New は Post ID と結果から Draw を生成する。
+func New(postID, result string) (*Draw, error) {
+	if postID == "" {
+		return nil, ErrEmptyPostID
+	}
+	if result == "" {
+		return nil, ErrEmptyResult
+	}
+
+	return &Draw{
+		postID: postID,
+		result: result,
+	}, nil
+}
+
+// FromPost は ready な Post から Draw を生成する。
+func FromPost(p *post.Post, result string) (*Draw, error) {
+	if p == nil {
+		return nil, ErrNilPost
+	}
+	if !p.IsReady() {
+		return nil, ErrPostNotReady
+	}
+
+	return New(p.ID(), result)
+}
+
+// PostID は元となった Post の ID を返す。
+func (d *Draw) PostID() string {
+	return d.postID
+}
+
+// Result はおみくじ結果の本文を返す。
+func (d *Draw) Result() string {
+	return d.result
+}

--- a/backend/internal/domain/draw/draw_test.go
+++ b/backend/internal/domain/draw/draw_test.go
@@ -1,0 +1,65 @@
+package draw
+
+import (
+	"testing"
+
+	"backend/internal/domain/post"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	draw, err := New("post-id", "やさしい言葉")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if draw.PostID() != "post-id" {
+		t.Fatalf("unexpected post id: %s", draw.PostID())
+	}
+	if draw.Result() != "やさしい言葉" {
+		t.Fatalf("unexpected result: %s", draw.Result())
+	}
+}
+
+func TestNew_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New("post-id", ""); err != ErrEmptyResult {
+		t.Fatalf("expected ErrEmptyResult but got %v", err)
+	}
+}
+
+func TestFromPost(t *testing.T) {
+	t.Parallel()
+
+	p, err := post.New("post-id", "闇が深い")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := p.MarkReady(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	draw, err := FromPost(p, "やさしい言葉")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if draw.PostID() != p.ID() {
+		t.Fatalf("expected post id %s but got %s", p.ID(), draw.PostID())
+	}
+}
+
+func TestFromPost_NotReady(t *testing.T) {
+	t.Parallel()
+
+	p, err := post.New("post-id", "闇")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := FromPost(p, "まだ早い"); err != ErrPostNotReady {
+		t.Fatalf("expected ErrPostNotReady but got %v", err)
+	}
+}

--- a/backend/internal/domain/post/post.go
+++ b/backend/internal/domain/post/post.go
@@ -1,0 +1,90 @@
+package post
+
+import "errors"
+
+// Status は闇投稿の状態を表す。
+type Status string
+
+const (
+	StatusPending Status = "pending"
+	StatusReady   Status = "ready"
+)
+
+var (
+	// ErrEmptyContent は投稿内容が空の場合に返される。
+	ErrEmptyContent = errors.New("post: content is empty")
+	// ErrInvalidStatus は不正な状態が指定された際に返される。
+	ErrInvalidStatus = errors.New("post: invalid status")
+	// ErrInvalidStatusTransition は許可されていない状態遷移が要求された際に返される。
+	ErrInvalidStatusTransition = errors.New("post: invalid status transition")
+)
+
+// Post は闇投稿そのもの。
+type Post struct {
+	id      string
+	content string
+	status  Status
+}
+
+// New は新しい闇投稿を pending 状態で作成する。
+func New(id, content string) (*Post, error) {
+	if content == "" {
+		return nil, ErrEmptyContent
+	}
+
+	return &Post{
+		id:      id,
+		content: content,
+		status:  StatusPending,
+	}, nil
+}
+
+// Restore は既存の投稿を再構築する。
+func Restore(id, content string, status Status) (*Post, error) {
+	if content == "" {
+		return nil, ErrEmptyContent
+	}
+	if !status.isValid() {
+		return nil, ErrInvalidStatus
+	}
+
+	return &Post{
+		id:      id,
+		content: content,
+		status:  status,
+	}, nil
+}
+
+// ID は投稿の識別子を返す。
+func (p *Post) ID() string {
+	return p.id
+}
+
+// Content は投稿内容を返す。
+func (p *Post) Content() string {
+	return p.content
+}
+
+// Status は現在の状態を返す。
+func (p *Post) Status() Status {
+	return p.status
+}
+
+// IsReady は ready 状態かどうかを返す。
+func (p *Post) IsReady() bool {
+	return p.status == StatusReady
+}
+
+// MarkReady は pending -> ready の状態遷移のみを許可する。
+func (p *Post) MarkReady() error {
+	if p.status != StatusPending {
+		return ErrInvalidStatusTransition
+	}
+
+	p.status = StatusReady
+	return nil
+}
+
+func (s Status) isValid() bool {
+	return s == StatusPending || s == StatusReady
+}

--- a/backend/internal/domain/post/post_test.go
+++ b/backend/internal/domain/post/post_test.go
@@ -1,0 +1,68 @@
+package post
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	post, err := New("post-id", "闇がおおい")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if post.ID() != "post-id" {
+		t.Fatalf("unexpected id: %s", post.ID())
+	}
+	if post.Content() != "闇がおおい" {
+		t.Fatalf("unexpected content: %s", post.Content())
+	}
+	if post.Status() != StatusPending {
+		t.Fatalf("expected pending but got %s", post.Status())
+	}
+}
+
+func TestNew_EmptyContent(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New("post-id", ""); err != ErrEmptyContent {
+		t.Fatalf("expected ErrEmptyContent but got %v", err)
+	}
+}
+
+func TestMarkReady(t *testing.T) {
+	t.Parallel()
+
+	post, err := New("id", "闇")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := post.MarkReady(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if post.Status() != StatusReady {
+		t.Fatalf("expected ready but got %s", post.Status())
+	}
+}
+
+func TestMarkReady_InvalidTransition(t *testing.T) {
+	t.Parallel()
+
+	post, err := Restore("id", "闇", StatusReady)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := post.MarkReady(); err != ErrInvalidStatusTransition {
+		t.Fatalf("expected ErrInvalidStatusTransition but got %v", err)
+	}
+}
+
+func TestRestore_InvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Restore("id", "闇", Status("unknown")); err != ErrInvalidStatus {
+		t.Fatalf("expected ErrInvalidStatus but got %v", err)
+	}
+}


### PR DESCRIPTION
Post/Draw のドメインモデルを追加し、content/result の必須チェックと pending→ready 以外の遷移を禁止。
FromPost で ready な Post からのみ Draw を生成。
Post/Draw の正常系・異常系ユニットテストを作成。

動作確認: go test ./internal/domain/...

closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced post management system with lifecycle state tracking (pending and ready states)
  * Posts can be created and transitioned through defined states with validation
  * Added draw functionality to create and associate draw results with posts
  * Implemented comprehensive validation to ensure proper state transitions and data integrity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->