### PR TITLE
chore: VS Code tasksでフロントエンド・バックエンド並行起動を追加

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,19 +9,7 @@
         "cwd": "${workspaceFolder}/frontend"
       },
       "isBackground": true,
-      "problemMatcher": {
-        "pattern": {
-          "regexp": "^(.*)$",
-          "file": 1,
-          "location": 2,
-          "message": 3
-        },
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": ".*",
-          "endsPattern": "(Local:|started server on)"
-        }
-      },
+      "problemMatcher": [],
       "presentation": {
         "reveal": "always",
         "panel": "dedicated",
@@ -36,19 +24,7 @@
         "cwd": "${workspaceFolder}/backend"
       },
       "isBackground": true,
-      "problemMatcher": {
-        "pattern": {
-          "regexp": "^(.*)$",
-          "file": 1,
-          "location": 2,
-          "message": 3
-        },
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": ".*",
-          "endsPattern": "(Listening and serving HTTP on)"
-        }
-      },
+      "problemMatcher": [],
       "presentation": {
         "reveal": "always",
         "panel": "dedicated",


### PR DESCRIPTION
## What
`.vscode/tasks.json`を追加し、フロントエンド（Next.js）とバックエンド（Go API）を並行起動できるタスクを作成しました。
`Dev: All`タスクで両方を同時に起動できます。

## Why
開発時に毎回フロントとバックエンドを別々のターミナルで起動するのが手間だったため、VS Codeのタスク機能で一括起動できるようにしました。

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added development task configurations to start the frontend dev server, start the backend API server, and run both in parallel to streamline local setup and improve developer workflow efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->