### PR TITLE
feat: LLM整形を実装

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -1,10 +1,59 @@
 package main
 
-import "log"
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"backend/internal/adapter/llm/gemini"
+	"backend/internal/adapter/repository/memory"
+	"backend/internal/app"
+	"backend/internal/domain/post"
+	workerusecase "backend/internal/usecase/worker"
+)
 
 /**
  * 非同期処理する別プロセスのエントリポイント
  */
 func main() {
-	log.Println("worker not implemented yet")
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	repo := memory.NewPostRepository()
+	seedFromEnv(repo)
+
+	formatter := gemini.NewFormatter()
+	formatPending := workerusecase.NewFormatPending(repo, formatter)
+
+	workerApp := app.NewWorkerApp(formatPending, nil, log.Default())
+
+	mode := os.Getenv("WORKER_MODE")
+	if mode == "" {
+		mode = string(app.WorkerModePolling)
+	}
+
+	if err := workerApp.Run(ctx, app.WorkerMode(mode)); err != nil {
+		log.Fatalf("worker stopped: %v", err)
+	}
+}
+
+func seedFromEnv(repo *memory.PostRepository) {
+	content := os.Getenv("SEED_POST_CONTENT")
+	if content == "" {
+		return
+	}
+
+	id := fmt.Sprintf("seed-%d", time.Now().UnixNano())
+	p, err := post.New(id, content)
+	if err != nil {
+		log.Printf("worker: failed to seed pending post: %v", err)
+		return
+	}
+
+	repo.Insert(p)
+	log.Printf("worker: seeded pending post %s", id)
 }

--- a/backend/internal/adapter/llm/gemini/formatter.go
+++ b/backend/internal/adapter/llm/gemini/formatter.go
@@ -1,0 +1,26 @@
+package gemini
+
+import (
+	"context"
+	"log"
+
+	"backend/internal/port/llm"
+)
+
+var _ llm.Formatter = (*Formatter)(nil)
+
+// Formatter は Gemini 呼び出しのダミー実装。
+// 実プロダクションではここで本物の Gemini API を呼び出す。
+type Formatter struct{}
+
+// NewFormatter は Formatter を生成する。
+func NewFormatter() *Formatter {
+	return &Formatter{}
+}
+
+// Format は与えられたテキストを整形する。
+// ひとまずパススルー実装としてログのみ出力する。
+func (f *Formatter) Format(ctx context.Context, content string) (string, error) {
+	log.Printf("gemini formatter called (len=%d)", len(content))
+	return content, nil
+}

--- a/backend/internal/adapter/repository/memory/post_repository.go
+++ b/backend/internal/adapter/repository/memory/post_repository.go
@@ -1,0 +1,70 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"backend/internal/domain/post"
+	"backend/internal/port/repository"
+)
+
+var _ repository.PostRepository = (*PostRepository)(nil)
+
+// PostRepository はローカル開発向けの簡易インメモリ実装。
+type PostRepository struct {
+	mu    sync.Mutex
+	posts []*post.Post
+}
+
+// NewPostRepository は初期化する。
+func NewPostRepository() *PostRepository {
+	return &PostRepository{
+		posts: make([]*post.Post, 0),
+	}
+}
+
+// Insert は pending 投稿を追加する（デバッグ用）。
+func (r *PostRepository) Insert(p *post.Post) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.posts = append(r.posts, clonePost(p))
+}
+
+// FindPending は pending な投稿を取得する。
+func (r *PostRepository) FindPending(context.Context) (*post.Post, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, p := range r.posts {
+		if p.Status() == post.StatusPending {
+			return clonePost(p), nil
+		}
+	}
+	return nil, nil
+}
+
+// Update は投稿を保存する。
+func (r *PostRepository) Update(ctx context.Context, updated *post.Post) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i, p := range r.posts {
+		if p.ID() == updated.ID() {
+			r.posts[i] = clonePost(updated)
+			return nil
+		}
+	}
+
+	r.posts = append(r.posts, clonePost(updated))
+	return nil
+}
+
+func clonePost(p *post.Post) *post.Post {
+	cloned, err := post.Restore(p.ID(), p.Content(), p.Status())
+	if err != nil {
+		// Restore only fails for invalid data, which should never happen here.
+		panic(err)
+	}
+	return cloned
+}

--- a/backend/internal/app/worker.go
+++ b/backend/internal/app/worker.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"backend/internal/port/queue"
+	usecaseworker "backend/internal/usecase/worker"
+)
+
+// WorkerMode はワーカーの実行モード。
+type WorkerMode string
+
+const (
+	// WorkerModeQueue はジョブキュー経由の実行。
+	WorkerModeQueue WorkerMode = "queue"
+	// WorkerModePolling は DB を定期ポーリングして自己完結的に実行。
+	WorkerModePolling WorkerMode = "polling"
+
+	defaultPollInterval = 5 * time.Second
+)
+
+// WorkerApp は LLM 整形ワーカーのエントリポイント。
+type WorkerApp struct {
+	formatPending *usecaseworker.FormatPending
+	queue         queue.JobQueue
+	logger        *log.Logger
+	pollInterval  time.Duration
+}
+
+// WorkerOption は WorkerApp のオプション。
+type WorkerOption func(*WorkerApp)
+
+// WithPollInterval はポーリング間隔を設定する。
+func WithPollInterval(d time.Duration) WorkerOption {
+	return func(app *WorkerApp) {
+		if d > 0 {
+			app.pollInterval = d
+		}
+	}
+}
+
+// NewWorkerApp は WorkerApp を生成する。
+func NewWorkerApp(formatPending *usecaseworker.FormatPending, q queue.JobQueue, logger *log.Logger, opts ...WorkerOption) *WorkerApp {
+	if logger == nil {
+		logger = log.Default()
+	}
+	app := &WorkerApp{
+		formatPending: formatPending,
+		queue:         q,
+		logger:        logger,
+		pollInterval:  defaultPollInterval,
+	}
+
+	for _, opt := range opts {
+		opt(app)
+	}
+
+	return app
+}
+
+// Run は指定モードでワーカーを起動する。
+func (a *WorkerApp) Run(ctx context.Context, mode WorkerMode) error {
+	switch mode {
+	case WorkerModeQueue:
+		if a.queue == nil {
+			return errors.New("worker queue not configured")
+		}
+		return a.queue.RunWorker(ctx, queue.HandlerFunc(func(ctx context.Context, _ []byte) error {
+			return a.runOnce(ctx)
+		}))
+	case WorkerModePolling:
+		return a.runPolling(ctx)
+	default:
+		return errors.New("unknown worker mode")
+	}
+}
+
+func (a *WorkerApp) runPolling(ctx context.Context) error {
+	ticker := time.NewTicker(a.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		_ = a.runOnce(ctx)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *WorkerApp) runOnce(ctx context.Context) error {
+	err := a.formatPending.Run(ctx)
+	if err != nil {
+		a.logger.Printf("worker: failed to process pending post: %v", err)
+	}
+	return err
+}

--- a/backend/internal/domain/post/post.go
+++ b/backend/internal/domain/post/post.go
@@ -65,6 +65,16 @@ func (p *Post) Content() string {
 	return p.content
 }
 
+// UpdateContent は投稿内容を更新する。
+func (p *Post) UpdateContent(content string) error {
+	if content == "" {
+		return ErrEmptyContent
+	}
+
+	p.content = content
+	return nil
+}
+
 // Status は現在の状態を返す。
 func (p *Post) Status() Status {
 	return p.status

--- a/backend/internal/domain/post/post_test.go
+++ b/backend/internal/domain/post/post_test.go
@@ -66,3 +66,32 @@ func TestRestore_InvalidStatus(t *testing.T) {
 		t.Fatalf("expected ErrInvalidStatus but got %v", err)
 	}
 }
+
+func TestUpdateContent(t *testing.T) {
+	t.Parallel()
+
+	p, err := New("id", "before")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := p.UpdateContent("after"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Content() != "after" {
+		t.Fatalf("expected updated content but got %s", p.Content())
+	}
+}
+
+func TestUpdateContent_Empty(t *testing.T) {
+	t.Parallel()
+
+	p, err := New("id", "闇")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := p.UpdateContent(""); err != ErrEmptyContent {
+		t.Fatalf("expected ErrEmptyContent but got %v", err)
+	}
+}

--- a/backend/internal/port/llm/formatter.go
+++ b/backend/internal/port/llm/formatter.go
@@ -1,0 +1,8 @@
+package llm
+
+import "context"
+
+// Formatter は LLM で投稿本文を整形するためのインターフェース。
+type Formatter interface {
+	Format(ctx context.Context, content string) (string, error)
+}

--- a/backend/internal/port/queue/job_queue.go
+++ b/backend/internal/port/queue/job_queue.go
@@ -1,0 +1,21 @@
+package queue
+
+import "context"
+
+// JobQueue は Cloud Tasks などのジョブキューからワーカーを起動するための抽象.
+type JobQueue interface {
+	RunWorker(ctx context.Context, handler Handler) error
+}
+
+// Handler は受け取ったジョブを処理する関数.
+type Handler interface {
+	Handle(ctx context.Context, payload []byte) error
+}
+
+// HandlerFunc は Handler を関数で表現するためのアダプタ.
+type HandlerFunc func(ctx context.Context, payload []byte) error
+
+// Handle は f(ctx, payload) を呼び出す。
+func (f HandlerFunc) Handle(ctx context.Context, payload []byte) error {
+	return f(ctx, payload)
+}

--- a/backend/internal/port/repository/post_repository.go
+++ b/backend/internal/port/repository/post_repository.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"context"
+
+	"backend/internal/domain/post"
+)
+
+// PostRepository は闇投稿を永続化するための抽象.
+type PostRepository interface {
+	// FindPending は pending 状態の投稿を 1 件返す.
+	// 見つからなかった場合は (nil, nil) を返す。
+	FindPending(ctx context.Context) (*post.Post, error)
+	// Update は投稿の内容や状態を保存する。
+	Update(ctx context.Context, p *post.Post) error
+}

--- a/backend/internal/usecase/worker/format_pending.go
+++ b/backend/internal/usecase/worker/format_pending.go
@@ -1,0 +1,54 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"backend/internal/port/llm"
+	"backend/internal/port/repository"
+)
+
+// FormatPending は pending 投稿を LLM に投げて ready へ遷移させるユースケース。
+type FormatPending struct {
+	postRepo  repository.PostRepository
+	formatter llm.Formatter
+}
+
+// NewFormatPending は FormatPending を生成する。
+func NewFormatPending(postRepo repository.PostRepository, formatter llm.Formatter) *FormatPending {
+	return &FormatPending{
+		postRepo:  postRepo,
+		formatter: formatter,
+	}
+}
+
+// Run は pending 投稿を 1 件処理する。
+//
+// リトライ方針:
+// - Repository / Formatter の呼び出しが失敗した場合はエラーを返し、呼び出し元（Cloud Tasks 等）の再実行に任せる
+// - pending 投稿が見つからない場合は何もせずに終了し、次のジョブ／ポーリングで再度実行する
+func (uc *FormatPending) Run(ctx context.Context) error {
+	p, err := uc.postRepo.FindPending(ctx)
+	if err != nil {
+		return fmt.Errorf("find pending post: %w", err)
+	}
+	if p == nil {
+		return nil
+	}
+
+	formatted, err := uc.formatter.Format(ctx, p.Content())
+	if err != nil {
+		return fmt.Errorf("format content: %w", err)
+	}
+	if err := p.UpdateContent(formatted); err != nil {
+		return fmt.Errorf("update content: %w", err)
+	}
+	if err := p.MarkReady(); err != nil {
+		return fmt.Errorf("mark ready: %w", err)
+	}
+	if err := uc.postRepo.Update(ctx, p); err != nil {
+		return fmt.Errorf("update post: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/usecase/worker/format_pending_test.go
+++ b/backend/internal/usecase/worker/format_pending_test.go
@@ -1,0 +1,130 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"backend/internal/domain/post"
+)
+
+func TestFormatPending_RunSuccess(t *testing.T) {
+	t.Parallel()
+
+	p, err := post.New("id", "raw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	repo := &fakePostRepository{
+		pending: p,
+	}
+	formatter := &fakeFormatter{
+		output: "formatted",
+	}
+
+	usecase := NewFormatPending(repo, formatter)
+
+	if err := usecase.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !repo.updated {
+		t.Fatal("expected update to be called")
+	}
+	if repo.savedPost.Content() != "formatted" {
+		t.Fatalf("expected formatted content but got %s", repo.savedPost.Content())
+	}
+	if repo.savedPost.Status() != post.StatusReady {
+		t.Fatalf("expected status ready but got %s", repo.savedPost.Status())
+	}
+}
+
+func TestFormatPending_NoPending(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakePostRepository{}
+	usecase := NewFormatPending(repo, &fakeFormatter{})
+
+	if err := usecase.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.updated {
+		t.Fatal("update should not be called when no pending post")
+	}
+}
+
+func TestFormatPending_FormatError(t *testing.T) {
+	t.Parallel()
+
+	p, err := post.New("id", "raw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	usecase := NewFormatPending(&fakePostRepository{pending: p}, &fakeFormatter{err: errors.New("boom")})
+
+	if err := usecase.Run(context.Background()); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func TestFormatPending_UpdateError(t *testing.T) {
+	t.Parallel()
+
+	p, err := post.New("id", "raw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	repo := &fakePostRepository{
+		pending:   p,
+		updateErr: errors.New("db down"),
+	}
+
+	usecase := NewFormatPending(repo, &fakeFormatter{})
+
+	if err := usecase.Run(context.Background()); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+type fakePostRepository struct {
+	pending   *post.Post
+	findErr   error
+	updateErr error
+
+	updated   bool
+	savedPost *post.Post
+}
+
+func (r *fakePostRepository) FindPending(context.Context) (*post.Post, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	return r.pending, nil
+}
+
+func (r *fakePostRepository) Update(ctx context.Context, p *post.Post) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updated = true
+	r.savedPost = p
+	return nil
+}
+
+type fakeFormatter struct {
+	output string
+	err    error
+}
+
+func (f *fakeFormatter) Format(context.Context, string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.output != "" {
+		return f.output, nil
+	}
+	return "formatted", nil
+}


### PR DESCRIPTION
LLM 整形ワーカーのユースケース FormatPending を実装し、pending 投稿取得→Gemini フォーマット→ready 更新の一連処理を組んだ。
Post.UpdateContent を追加し、LLM 整形結果をドメインオブジェクトに反映できるようにした。
ワーカーの DI/起動ロジック (internal/app/worker.go と cmd/worker/main.go) を整備し、ジョブキュー／ポーリング両方に対応。
Repository / Formatter / Queue の Port とモック実装、ユースケーステストを追加して go test ./internal/usecase/worker を通過させた。

codex的な不安な点
いまの cmd/worker はインメモリ Repo＋ダミー Formatter 固定なので、本番用の adapter を差し込む経路（設定 or DI ラッパー）が未整備な点が少し気になります。
FormatPending.Run が pending なしのとき何も返さない仕様なので、Cloud Tasks などジョブキューで起動した際に「仕事が無かったジョブ」も成功扱いになり、メトリクスや再実行制御がしづらいかもしれません。この挙動で問題ないか確認したいです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asynchronous worker system to process pending posts in real-time or on-demand.
  * Post content update capability with validation.
  * Flexible worker execution modes: queue-driven or polling-based processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->