### PR TITLE
chore: Firestore切替をDIでサポート

### DIFF
--- a/backend/internal/app/di.go
+++ b/backend/internal/app/di.go
@@ -63,7 +63,7 @@ func provideDrawRepository(ctx context.Context, infra *Infra) (repository.DrawRe
 	}
 
 	repo := memory.NewInMemoryDrawRepository()
-	if err := seedDraws(repo, mode); err != nil {
+	if err := seedDraws(ctx, repo, mode); err != nil {
 		return nil, err
 	}
 	return repo, nil
@@ -78,7 +78,7 @@ func newFirestoreDrawRepository(infra *Infra) (repository.DrawRepository, error)
 	return firestoreadapter.NewDrawRepository(client)
 }
 
-func seedDraws(repo repository.DrawRepository, mode string) error {
+func seedDraws(ctx context.Context, repo repository.DrawRepository, mode string) error {
 	samples := []struct {
 		id      string
 		content string
@@ -102,7 +102,7 @@ func seedDraws(repo repository.DrawRepository, mode string) error {
 		if sample.ready {
 			draw.MarkVerified()
 		}
-		if err := repo.Create(context.Background(), draw); err != nil && err != repository.ErrDrawAlreadyExists {
+		if err := repo.Create(ctx, draw); err != nil && err != repository.ErrDrawAlreadyExists {
 			return err
 		}
 	}


### PR DESCRIPTION
- internal/app/di.go に Firestore リポジトリを選択できる分岐と newFirestoreDrawRepository を追加し、DRAW_REPOSITORY_MODE=firestore で Firestore 実装を利用できるようにした。

- Firestore クライアント未初期化時は明示的にエラーを返し、既存のメモリ/エラーモードの挙動には影響を与えていないことを確認した。

close #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Firestore storage backend selectable via environment configuration; in-memory remains the default.
  * When Firestore is enabled, initial seed data will be created in Firestore during startup.
  * Improved startup initialization to support the new Firestore option and its initialization flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->