### PR TITLE
chore: Firestoreシード手順を整備

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -226,6 +226,26 @@ API / Worker から Firestore を利用する際は、`internal/app` が 1 度�
 3. `FIRESTORE_EMULATOR_HOST` は未設定（実サービス接続）。
 4. `go run ./cmd/api` もしくはビルド済みバイナリを実行。
 
+### コレクションスキーマ
+
+| コレクション | 主キー | フィールド |
+| --- | --- | --- |
+| `posts/{post_id}` | `post_id` | `content` (string), `status` (`pending`/`ready`), `created_at`, `updated_at` |
+| `draws/{post_id}` | `post_id` (Post と同じ ID) | `result` (string), `status` (`pending`/`verified`/`rejected`), `created_at` |
+
+### 初期データ投入（シード）
+
+`cmd/seed` が Firestore に posts/draws のサンプルデータを投入します。Verified な draw を含む状態が一度で作成されるため、API を Firestore に切り替えた後でもすぐに挙動を確認できます。
+
+```
+cd backend
+export GOOGLE_CLOUD_PROJECT=your-project
+# Firestore Emulator を使う場合は FIRESTORE_EMULATOR_HOST も設定
+go run ./cmd/seed
+```
+
+エミュレータ利用時は `gcloud beta emulators firestore start --host-port=localhost:8080` を別ターミナルで起動してから実行してください。
+
 ---
 
 ## エラーコメント規約

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"backend/internal/app"
+	drawdomain "backend/internal/domain/draw"
+	"backend/internal/domain/post"
+
+	"cloud.google.com/go/firestore"
+)
+
+// seedPost は Firestore posts コレクションへ投入するサンプルデータ。
+type seedPost struct {
+	ID      string
+	Content string
+	Ready   bool
+}
+
+// seedDraw は Firestore draws コレクションへ投入するサンプルデータ。
+type seedDraw struct {
+	PostID   string
+	Result   string
+	Verified bool
+}
+
+func main() {
+	ctx := context.Background()
+
+	infra, err := app.NewInfra(ctx)
+	if err != nil {
+		log.Fatalf("init infra: %v", err)
+	}
+	defer func() {
+		if err := infra.Close(); err != nil {
+			log.Printf("close infra: %v", err)
+		}
+	}()
+
+	client := infra.Firestore()
+	if client == nil {
+		log.Fatalf("firestore client is not initialized; set GOOGLE_CLOUD_PROJECT and related env vars")
+	}
+
+	if err := seedFirestore(ctx, client); err != nil {
+		log.Fatalf("seed firestore: %v", err)
+	}
+
+	log.Println("firestore seeding completed successfully")
+}
+
+// seedFirestore は posts / draws へ初期データを投入する。
+func seedFirestore(ctx context.Context, client *firestore.Client) error {
+	posts := []seedPost{
+		{ID: "post-alpha", Content: "先が見えずに彷徨っている", Ready: false},
+		{ID: "post-beta", Content: "光が差す日を待っている", Ready: true},
+		{ID: "post-gamma", Content: "心の叫びを誰かに聞いてほしい", Ready: true},
+	}
+
+	draws := []seedDraw{
+		{PostID: "post-beta", Result: "夜明けはすぐそばにあります", Verified: true},
+		{PostID: "post-gamma", Result: "焦らずとも道は開けるでしょう", Verified: true},
+	}
+
+	if err := seedPosts(ctx, client, posts); err != nil {
+		return err
+	}
+	if err := seedDraws(ctx, client, draws); err != nil {
+		return err
+	}
+	return nil
+}
+
+// seedPosts は posts コレクションにドキュメントを保存する。
+func seedPosts(ctx context.Context, client *firestore.Client, posts []seedPost) error {
+	// 1件ずつ取り出して処理する
+	for _, p := range posts {
+		postEntity, err := post.New(post.DarkPostID(p.ID), post.DarkContent(p.Content))
+		if err != nil {
+			return fmt.Errorf("build post %s: %w", p.ID, err)
+		}
+		if p.Ready {
+			if err := postEntity.MarkReady(); err != nil {
+				return fmt.Errorf("mark ready %s: %w", p.ID, err)
+			}
+		}
+
+		// Firestore に upsert するフィールド群。
+		data := map[string]any{
+			"post_id":    string(postEntity.ID()),
+			"content":    string(postEntity.Content()),
+			"status":     string(postEntity.Status()),
+			"created_at": firestore.ServerTimestamp,
+			"updated_at": firestore.ServerTimestamp,
+		}
+
+		if _, err := client.Collection("posts").Doc(p.ID).Set(ctx, data); err != nil {
+			return fmt.Errorf("set post document %s: %w", p.ID, err)
+		}
+	}
+	return nil
+}
+
+// seedDraws は draws コレクションに検証済みの結果を保存する。
+func seedDraws(ctx context.Context, client *firestore.Client, draws []seedDraw) error {
+	for _, d := range draws {
+		drawEntity, err := drawdomain.New(post.DarkPostID(d.PostID), drawdomain.FormattedContent(d.Result))
+		if err != nil {
+			return fmt.Errorf("build draw %s: %w", d.PostID, err)
+		}
+		if d.Verified {
+			drawEntity.MarkVerified()
+		}
+
+		data := map[string]any{
+			"post_id":    string(drawEntity.PostID()),
+			"result":     string(drawEntity.Result()),
+			"status":     string(drawEntity.Status()),
+			"created_at": firestore.ServerTimestamp,
+		}
+
+		if _, err := client.Collection("draws").Doc(d.PostID).Set(ctx, data); err != nil {
+			return fmt.Errorf("set draw document %s: %w", d.PostID, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- cmd/seed/main.go を追加し、Infra から Firestore クライアントを初期化した上で posts/draws コレクションへ Verified データを投入する CLI を実装した。

- README に Firestore コレクションスキーマと cmd/seed の実行手順を追記し、ローカル/本番どちらでも初期データを再現できるようにした。

close #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend documentation with Firestore collection schema for posts and draws collections
  * Added seeding procedure with command examples and emulator configuration guidance

* **New Features**
  * Added utility to seed Firestore with initial post and draw sample data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->