### PR TITLE
test: Firestoreリポジトリの統合テストを追加

### DIFF
--- a/backend/internal/adapter/repository/firestore/firestore_test.go
+++ b/backend/internal/adapter/repository/firestore/firestore_test.go
@@ -43,8 +43,6 @@ func truncateCollection(t *testing.T, client *firestore.Client, collection strin
 	t.Helper()
 	ctx := context.Background()
 	iter := client.Collection(collection).Documents(ctx)
-	batch := client.Batch()
-	count := 0
 	for {
 		doc, err := iter.Next()
 		if err != nil {
@@ -53,19 +51,9 @@ func truncateCollection(t *testing.T, client *firestore.Client, collection strin
 			}
 			t.Fatalf("iterate %s: %v", collection, err)
 		}
-		batch.Delete(doc.Ref)
-		count++
-		if count == 500 {
-			if _, err := batch.Commit(ctx); err != nil {
-				t.Fatalf("commit delete batch: %v", err)
-			}
-			batch = client.Batch()
-			count = 0
-		}
-	}
-	if count > 0 {
-		if _, err := batch.Commit(ctx); err != nil {
-			t.Fatalf("commit delete batch: %v", err)
+		// エミュレータ上のテストなので 1 件ずつ削除すれば十分。
+		if _, err := doc.Ref.Delete(ctx); err != nil {
+			t.Fatalf("delete doc %s: %v", doc.Ref.ID, err)
 		}
 	}
 }


### PR DESCRIPTION
- internal/adapter/repository/firestore/firestore_test.go に Firestore エミュレータを前提とした統合テストを追加し、DrawRepository の Create/Get/ListReady を end-to-end で検証できるようにしました。環境変数が未設定の際は自動的にスキップし、安全にコレクションをクリーンアップする仕組みも整備しました。

- README の Firestore 章にコレクションスキーマ、シードコマンド、統合テストの実行手順を追記し、ローカル/CI で環境変数を含めた手順が共有できるようにしました。

close #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for Firestore-backed draw storage to improve reliability and validate create/get/list flows.
  * Included emulator-aware test helpers for connecting to the test datastore and cleaning collections to ensure isolated, repeatable runs.
  * Added a full integration scenario that persists, retrieves, and lists draws to assert correct status and results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->