### PR TITLE
feat: 画面ステート骨格を追加

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useState } from "react";
 
 export default function Home() {
-  const [currentStep, setCurrentStep] = useState<"input" | "loading" | "result">(
-    "input",
-  );
+  const [currentStep, setCurrentStep] = useState<
+    "input" | "loading" | "result"
+  >("input");
 
   useEffect(() => {
     if (currentStep !== "loading") {
@@ -38,7 +38,7 @@ export default function Home() {
               placeholder="ここに闇を投げる（最大140字）"
             />
             <button
-              className="rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white"
+              className="rounded-full bg-zinc-900 px-6 py-3 font-semibold text-sm text-white"
               type="button"
               onClick={() => setCurrentStep("loading")}
             >
@@ -49,7 +49,7 @@ export default function Home() {
 
         {currentStep === "loading" && (
           <section className="flex flex-col items-center gap-4 text-center">
-            <p className="text-base font-medium">
+            <p className="font-medium text-base">
               少し待っていて、あなたのためのお告げを探すから。
             </p>
             <div className="h-2 w-full max-w-sm overflow-hidden rounded-full bg-zinc-100">
@@ -60,11 +60,11 @@ export default function Home() {
 
         {currentStep === "result" && (
           <section className="flex flex-col gap-4 text-center">
-            <p className="text-base font-medium">
+            <p className="font-medium text-base">
               今日の闇みくじ: ここに結果テキストが入ります。
             </p>
             <button
-              className="rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-700"
+              className="rounded-full border border-zinc-300 px-6 py-3 font-semibold text-sm text-zinc-700"
               type="button"
               onClick={() => setCurrentStep("input")}
             >


### PR DESCRIPTION
-  1ページ内で input/loading/result のステート切替を実装し、ボタンとタイマーで遷移する仮UIを用意
-  画面フローの最短骨格を先に固めるため
- 未実施（手動で input→loading→result→input の遷移確認想定）

close #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an interactive three-step workflow (input → loading → result).
  * Input phase: text area with submit button.
  * Loading phase: waiting message and simple loading bar; advances automatically after 1.5s.
  * Result phase: shows outcome and allows restarting.
  * Refreshed layout and Japanese labels/typography reflecting a new theme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->