### PR TITLE
feat: POST /posts クライアントを追加

### DIFF
--- a/frontend/src/lib/posts.ts
+++ b/frontend/src/lib/posts.ts
@@ -1,0 +1,48 @@
+import { API_BASE_URL } from "./api";
+
+export type CreatePostRequest = {
+  post_id: string;
+  content: string;
+};
+
+export type CreatePostResponse = {
+  post_id: string;
+};
+
+type ApiErrorResponse = {
+  message?: string;
+};
+
+/**
+ * 闇投稿を登録する。
+ */
+export const createPost = async (content: string) => {
+  const postId = crypto.randomUUID();
+  const payload: CreatePostRequest = {
+    post_id: postId,
+    content,
+  };
+
+  const response = await fetch(`${API_BASE_URL}/posts`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let errorMessage = "投稿に失敗しました";
+    try {
+      const data = (await response.json()) as ApiErrorResponse;
+      if (data.message) {
+        errorMessage = data.message;
+      }
+    } catch {
+      // 何も取得できない場合は既定文言で返す。
+    }
+    throw new Error(errorMessage);
+  }
+
+  return (await response.json()) as CreatePostResponse;
+};


### PR DESCRIPTION
変更内容: POST /posts の fetch ラッパーと型定義を追加し、UUID で post_id を生成
変更理由: 闇投稿登録のAPI連携を進めるため
動作確認: 未実施
