### PR TITLE
feat: Worker で DrawRepository を注入

### DIFF
--- a/backend/internal/usecase/worker/format_pending.go
+++ b/backend/internal/usecase/worker/format_pending.go
@@ -25,6 +25,7 @@ var (
 // 整形待ち投稿の整形から公開準備までを担う。
 type FormatPendingUsecase struct {
 	postRepo repository.PostRepository
+	drawRepo repository.DrawRepository
 	llm      llm.Formatter
 	jobQueue queue.JobQueue // TODO: 再整形の再キュー処理で利用予定
 }
@@ -32,11 +33,13 @@ type FormatPendingUsecase struct {
 // 依存をまとめて整形用ユースケースを組み立てる。
 func NewFormatPendingUsecase(
 	postRepo repository.PostRepository,
+	drawRepo repository.DrawRepository,
 	llmFormatter llm.Formatter,
 	jobQueue queue.JobQueue,
 ) *FormatPendingUsecase {
 	return &FormatPendingUsecase{
 		postRepo: postRepo,
+		drawRepo: drawRepo,
 		llm:      llmFormatter,
 		jobQueue: jobQueue,
 	}

--- a/backend/internal/usecase/worker/format_pending_test.go
+++ b/backend/internal/usecase/worker/format_pending_test.go
@@ -29,7 +29,7 @@ func TestFormatPendingUsecase_Success(t *testing.T) {
 			FormattedContent: "formatted",
 		},
 	}
-	usecase := NewFormatPendingUsecase(repo, formatter, testutil.StubJobQueue{})
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, formatter, testutil.StubJobQueue{})
 
 	if err := usecase.Execute(context.Background(), "post-1"); err != nil {
 		t.Fatalf("execute returned error: %v", err)
@@ -44,7 +44,7 @@ func TestFormatPendingUsecase_Success(t *testing.T) {
 
 func TestFormatPendingUsecase_PostNotFound(t *testing.T) {
 	repo := testutil.NewStubPostRepository(nil)
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{}, testutil.StubJobQueue{})
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{}, testutil.StubJobQueue{})
 
 	err := usecase.Execute(context.Background(), "unknown")
 	if !errors.Is(err, ErrPostNotFound) {
@@ -55,7 +55,7 @@ func TestFormatPendingUsecase_PostNotFound(t *testing.T) {
 func TestFormatPendingUsecase_GetGenericError(t *testing.T) {
 	repo := testutil.NewStubPostRepository(nil)
 	repo.GetErr = errors.New("get failed")
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{}, testutil.StubJobQueue{})
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{}, testutil.StubJobQueue{})
 
 	err := usecase.Execute(context.Background(), "post-1")
 	if !errors.Is(err, repo.GetErr) {
@@ -66,7 +66,7 @@ func TestFormatPendingUsecase_GetGenericError(t *testing.T) {
 func TestFormatPendingUsecase_FormatterUnavailable(t *testing.T) {
 	p, _ := post.New(post.DarkPostID("post-1"), post.DarkContent("test"))
 	repo := testutil.NewStubPostRepository(p)
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatErr: llm.ErrFormatterUnavailable,
 	}, testutil.StubJobQueue{})
 
@@ -79,7 +79,7 @@ func TestFormatPendingUsecase_FormatterUnavailable(t *testing.T) {
 func TestFormatPendingUsecase_ContentRejected(t *testing.T) {
 	p, _ := post.New(post.DarkPostID("post-1"), post.DarkContent("test"))
 	repo := testutil.NewStubPostRepository(p)
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatResult: &llm.FormatResult{DarkPostID: p.ID()},
 		ValidateErr:  llm.ErrContentRejected,
 	}, testutil.StubJobQueue{})
@@ -97,7 +97,7 @@ func TestFormatPendingUsecase_UpdateFailed(t *testing.T) {
 	p, _ := post.New(post.DarkPostID("post-1"), post.DarkContent("test"))
 	repo := testutil.NewStubPostRepository(p)
 	repo.UpdateErr = errors.New("update failed")
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatResult: &llm.FormatResult{DarkPostID: p.ID()},
 		ValidateResult: &llm.FormatResult{
 			DarkPostID:       p.ID(),
@@ -118,7 +118,7 @@ func TestFormatPendingUsecase_PostNotPending(t *testing.T) {
 		t.Fatalf("failed to mark ready: %v", err)
 	}
 	repo := testutil.NewStubPostRepository(p)
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatResult: &llm.FormatResult{DarkPostID: p.ID()},
 		ValidateResult: &llm.FormatResult{
 			DarkPostID:       p.ID(),
@@ -134,7 +134,7 @@ func TestFormatPendingUsecase_PostNotPending(t *testing.T) {
 }
 
 func TestFormatPendingUsecase_EmptyPostID(t *testing.T) {
-	usecase := NewFormatPendingUsecase(testutil.NewStubPostRepository(nil), &testutil.StubFormatter{}, testutil.StubJobQueue{})
+	usecase := NewFormatPendingUsecase(testutil.NewStubPostRepository(nil), testutil.StubDrawRepository{}, &testutil.StubFormatter{}, testutil.StubJobQueue{})
 	if err := usecase.Execute(context.Background(), ""); !errors.Is(err, ErrEmptyPostID) {
 		t.Fatalf("expected ErrEmptyPostID, got %v", err)
 	}
@@ -150,7 +150,7 @@ func TestFormatPendingUsecase_NilUsecase(t *testing.T) {
 func TestFormatPendingUsecase_ValidationNotVerified(t *testing.T) {
 	p, _ := post.New(post.DarkPostID("post-1"), post.DarkContent("test"))
 	repo := testutil.NewStubPostRepository(p)
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatResult: &llm.FormatResult{DarkPostID: p.ID()},
 		ValidateResult: &llm.FormatResult{
 			DarkPostID:       p.ID(),
@@ -168,7 +168,7 @@ func TestFormatPendingUsecase_ValidationNotVerified(t *testing.T) {
 }
 
 func TestFormatPendingUsecase_NilContext(t *testing.T) {
-	usecase := NewFormatPendingUsecase(testutil.NewStubPostRepository(nil), &testutil.StubFormatter{}, testutil.StubJobQueue{})
+	usecase := NewFormatPendingUsecase(testutil.NewStubPostRepository(nil), testutil.StubDrawRepository{}, &testutil.StubFormatter{}, testutil.StubJobQueue{})
 
 	var nilCtx context.Context
 	if err := usecase.Execute(nilCtx, "post-1"); !errors.Is(err, ErrNilContext) {
@@ -180,7 +180,7 @@ func TestFormatPendingUsecase_FormatGenericError(t *testing.T) {
 	p, _ := post.New(post.DarkPostID("post-1"), post.DarkContent("test"))
 	repo := testutil.NewStubPostRepository(p)
 	expectedErr := errors.New("format failed")
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatErr: expectedErr,
 	}, testutil.StubJobQueue{})
 
@@ -194,7 +194,7 @@ func TestFormatPendingUsecase_ValidateGenericError(t *testing.T) {
 	p, _ := post.New(post.DarkPostID("post-1"), post.DarkContent("test"))
 	repo := testutil.NewStubPostRepository(p)
 	expectedErr := errors.New("validate failed")
-	usecase := NewFormatPendingUsecase(repo, &testutil.StubFormatter{
+	usecase := NewFormatPendingUsecase(repo, testutil.StubDrawRepository{}, &testutil.StubFormatter{
 		FormatResult: &llm.FormatResult{DarkPostID: p.ID()},
 		ValidateErr:  expectedErr,
 	}, testutil.StubJobQueue{})

--- a/backend/internal/usecase/worker/testutil/test_doubles.go
+++ b/backend/internal/usecase/worker/testutil/test_doubles.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 
+	drawdomain "backend/internal/domain/draw"
 	"backend/internal/domain/post"
 	"backend/internal/port/llm"
 	"backend/internal/port/queue"
@@ -68,6 +69,32 @@ func (r *StubPostRepository) Update(ctx context.Context, p *post.Post) error {
 }
 
 var _ repository.PostRepository = (*StubPostRepository)(nil)
+
+// DrawRepository を埋めるだけの簡易スタブ。
+type StubDrawRepository struct{}
+
+/**
+ * Create 呼び出しを無視する。
+ */
+func (StubDrawRepository) Create(ctx context.Context, d *drawdomain.Draw) error {
+	return nil
+}
+
+/**
+ * GetByPostID は既定で見つからない扱いにする。
+ */
+func (StubDrawRepository) GetByPostID(ctx context.Context, postID post.DarkPostID) (*drawdomain.Draw, error) {
+	return nil, repository.ErrDrawNotFound
+}
+
+/**
+ * ListReady は空を返す。
+ */
+func (StubDrawRepository) ListReady(ctx context.Context) ([]*drawdomain.Draw, error) {
+	return nil, nil
+}
+
+var _ repository.DrawRepository = (*StubDrawRepository)(nil)
 
 // 整形と検証の結果を切り替えられるテスト用スタブ。
 type StubFormatter struct {


### PR DESCRIPTION
## 変更内容

- WorkerContainer で DrawRepository を Firestore から初期化し、FormatPendingUsecase に渡すよう DI を拡張
- DrawRepository 用のスタブ・ファクトリを追加し、worker/app 周りのテストを更新
- FormatPendingUsecase と testutil に DrawRepository の依存を追加して将来の draw 連携に備える

close #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Extended worker architecture to support draw data management
  * Updated usecase dependency injection to include draw repository

* **Tests**
  * Added draw repository test stubs and implementation tests
  * Expanded test coverage for draw repository operations and error handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->