### PR TITLE
chore: APIエラーハンドリングを共通化

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,3 +10,33 @@ export const API_BASE_URL = (() => {
   }
   return trimmedUrl;
 })();
+
+export type ApiErrorResponse = {
+  message?: string;
+};
+
+const statusMessageMap: Record<number, string> = {
+  400: "入力が正しくありません",
+  404: "データが見つかりません",
+  409: "すでに登録されています",
+  500: "サーバーで問題が発生しました",
+};
+
+/**
+ * API エラーメッセージを統一して返す。
+ */
+export const getApiErrorMessage = async (
+  response: Response,
+  fallbackMessage = "通信に失敗しました",
+): Promise<string> => {
+  const defaultMessage = statusMessageMap[response.status] ?? fallbackMessage;
+  try {
+    const data = (await response.json()) as ApiErrorResponse;
+    if (data.message) {
+      return data.message;
+    }
+  } catch {
+    // 何も取得できない場合は既定文言で返す。
+  }
+  return defaultMessage;
+};

--- a/frontend/src/lib/posts.ts
+++ b/frontend/src/lib/posts.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from "./api";
+import { API_BASE_URL, getApiErrorMessage } from "./api";
 
 export type CreatePostRequest = {
   post_id: string;
@@ -7,10 +7,6 @@ export type CreatePostRequest = {
 
 export type CreatePostResponse = {
   post_id: string;
-};
-
-type ApiErrorResponse = {
-  message?: string;
 };
 
 /**
@@ -38,15 +34,10 @@ export const createPost = async (content: string) => {
   window.clearTimeout(timeoutId);
 
   if (!response.ok) {
-    let errorMessage = "投稿に失敗しました";
-    try {
-      const data = (await response.json()) as ApiErrorResponse;
-      if (data.message) {
-        errorMessage = data.message;
-      }
-    } catch {
-      // 何も取得できない場合は既定文言で返す。
-    }
+    const errorMessage = await getApiErrorMessage(
+      response,
+      "投稿に失敗しました",
+    );
     throw new Error(errorMessage);
   }
 


### PR DESCRIPTION
変更内容: API_BASE_URL に共通エラー型と getApiErrorMessage を追加し、POST /posts のエラーハンドリングを統一
変更理由: 400/404/409/500 の扱いを揃えるため
補足: GET /draws/random 側は draws.ts 未取り込みのためこのPRでは対象外
動作確認: 未実施

close #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across the application with centralized API error messaging
  * Enhanced error messages now include HTTP status code-based user-friendly responses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->