### PR TITLE
feat: 懺悔フォームのバリデーションを追加

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,10 @@ type Step = "input" | "loading" | "result";
 
 export default function Home() {
   const [currentStep, setCurrentStep] = useState<Step>("input");
+  const [content, setContent] = useState("");
+  const contentLength = content.length;
+  const trimmedLength = content.trim().length;
+  const isSubmitDisabled = trimmedLength === 0 || contentLength > 140;
 
   useEffect(() => {
     if (currentStep !== "loading") {
@@ -32,12 +36,24 @@ export default function Home() {
           <section className="flex flex-col gap-4">
             <textarea
               className="min-h-[140px] w-full resize-none rounded-2xl border border-zinc-200 px-4 py-3 text-sm outline-none"
+              maxLength={140}
               placeholder="ここに闇を投げる（最大140字）"
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
             />
+            <div className="text-right text-xs text-zinc-500">
+              {contentLength}/140
+            </div>
             <button
-              className="rounded-full bg-zinc-900 px-6 py-3 font-semibold text-sm text-white"
+              className="rounded-full bg-zinc-900 px-6 py-3 font-semibold text-sm text-white disabled:cursor-not-allowed disabled:bg-zinc-400"
               type="button"
-              onClick={() => setCurrentStep("loading")}
+              onClick={() => {
+                if (isSubmitDisabled) {
+                  return;
+                }
+                setCurrentStep("loading");
+              }}
+              disabled={isSubmitDisabled}
             >
               懺悔する
             </button>


### PR DESCRIPTION
変更内容: 140字制限のテキスト入力と送信ボタンを追加し、空入力・超過時は送信不可にした
変更理由: フォーム仕様に合わせたバリデーションを入れるため
動作確認: 未実施

close #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text input field now enforces a 140-character maximum limit with a live character counter that displays the current character count out of the allowed maximum.
  * Submit button automatically disables when input is empty or exceeds 140 characters, with updated visual styling that clearly indicates the disabled state to users for better form validation feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->