### PR TITLE
feat: 結果表示の仮テキストを追加

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,9 @@ type Step = "input" | "loading" | "result";
 export default function Home() {
   const [currentStep, setCurrentStep] = useState<Step>("input");
   const [content, setContent] = useState("");
+  const [resultText] = useState(
+    "今日のきらくじ: ここに結果テキストが入ります。",
+  );
   const contentLength = content.length;
   const trimmedLength = content.trim().length;
   const isSubmitDisabled = trimmedLength === 0 || contentLength > 140;
@@ -82,9 +85,7 @@ export default function Home() {
 
         {currentStep === "result" && (
           <section className="flex flex-col gap-4 text-center">
-            <p className="font-medium text-base">
-              今日のきらくじ: ここに結果テキストが入ります。
-            </p>
+            <p className="font-medium text-base">{resultText}</p>
             <button
               className="rounded-full border border-zinc-300 px-6 py-3 font-semibold text-sm text-zinc-700"
               type="button"


### PR DESCRIPTION
変更内容: 結果テキストを state から表示し、再挑戦ボタンで input に戻す挙動を維持
変更理由: 結果表示の最小要件を満たすため
動作確認: 未実施
close #113 