### PR TITLE
fix: draw 作成失敗時の整合性と再キュー処理を整備

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -64,15 +64,14 @@ func runLoop(ctx context.Context, container *app.WorkerContainer) {
 			continue
 		}
 
-			// ジョブを処理し、失敗内容ごとにログの粒度を変える
-			if err := container.FormatPendingUsecase.Execute(ctx, string(postID)); err != nil {
-				switch {
-				// draw 保存に失敗したが再キュー済みのケース
-				case errors.Is(err, usecaseworker.ErrDrawCreationFailed):
-					log.Printf("draw creation failed (post=%s): %v (requeued)", postID, err)
+		// ジョブを処理し、失敗内容ごとにログの粒度を変える
+		if err := container.FormatPendingUsecase.Execute(ctx, string(postID)); err != nil {
+			switch {
+			// draw 保存に失敗したが再キュー済みのケース
+			case errors.Is(err, usecaseworker.ErrDrawCreationFailed):
+				log.Printf("draw creation failed (post=%s): %v (requeued)", postID, err)
 				// 再キューやロールバック自体が失敗した致命的ケース
-				case errors.Is(err, usecaseworker.ErrRequeueFailed),
-					errors.Is(err, usecaseworker.ErrPostRollbackFailed):
+			case errors.Is(err, usecaseworker.ErrRequeueFailed):
 				log.Printf("draw creation rollback failed (post=%s): %v", postID, err)
 			default:
 				// LLM や投稿の整形問題はログに残して次のジョブへ

--- a/backend/internal/usecase/worker/testutil/test_doubles.go
+++ b/backend/internal/usecase/worker/testutil/test_doubles.go
@@ -12,12 +12,10 @@ import (
 
 // テストで投稿取得を差し替えるための簡易リポジトリ。
 type StubPostRepository struct {
-	Store       map[post.DarkPostID]*post.Post
-	GetErr      error
-	UpdateErr   error
-	Updated     *post.Post
-	UpdateErrs  []error
-	UpdateCalls int
+	Store     map[post.DarkPostID]*post.Post
+	GetErr    error
+	UpdateErr error
+	Updated   *post.Post
 }
 
 /**
@@ -63,12 +61,6 @@ func (r *StubPostRepository) ListReady(ctx context.Context, limit int) ([]*post.
  * 更新内容を覚えて、必要ならエラーを返す。
  */
 func (r *StubPostRepository) Update(ctx context.Context, p *post.Post) error {
-	r.UpdateCalls++
-	if idx := r.UpdateCalls - 1; idx < len(r.UpdateErrs) {
-		if err := r.UpdateErrs[idx]; err != nil {
-			return err
-		}
-	}
 	if r.UpdateErr != nil {
 		return r.UpdateErr
 	}


### PR DESCRIPTION
## 変更内容

- FormatPendingUsecase で draw 保存を先に行い、成功後に Post を ready へ遷移させるよう順序を見直し。
- 保存失敗時は投稿を pending へロールバックし、format_jobs に再投入する仕組みを追加
- Worker の runLoop で draw 再キュー系エラーを区別してログ出力するよう改善
- 再キュー・ロールバックのユニットテストを追加し、StubPostRepository に複数回更新やエラー制御の機能を拡張
jobQueue の TODO コメントなど不要な記述は削除

close #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery for draw creation failures with automatic requeue mechanism
  * Fixed post state management to transition after successful draw creation
  
* **Improvements**
  * Added 400-character truncation for draw content normalization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->