### PR TITLE
chore: Dev: All にWorker起動を追加

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,10 +32,26 @@
       }
     },
     {
+      "label": "Backend: Worker",
+      "type": "shell",
+      "command": "go run ./cmd/worker",
+      "options": {
+        "cwd": "${workspaceFolder}/backend"
+      },
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      }
+    },
+    {
       "label": "Dev: All",
       "dependsOn": [
         "Frontend: Dev Server",
-        "Backend: API Server"
+        "Backend: API Server",
+        "Backend: Worker"
       ],
       "dependsOrder": "parallel",
       "problemMatcher": []

--- a/backend/README.md
+++ b/backend/README.md
@@ -185,6 +185,15 @@ go run ./cmd/api
 curl -i localhost:8080/draws/random
 ```
 
+## 開発時の同時起動
+
+API と Worker を同時に動かす場合は、別ターミナルで Worker を起動してください。
+
+```
+cd backend
+go run ./cmd/worker
+```
+
 環境変数 `DRAW_REPOSITORY_MODE` によりリポジトリの挙動を切り替えられます。  
 
 | モード | 起動例 | 期待されるレスポンス |


### PR DESCRIPTION
変更内容
- VSCodeタスクにBackend: Workerを追加
- Dev: All からAPI/Worker/Frontendを並列起動できるようにした
- backend/README.md にWorker起動手順を追記

理由
- 整形ジョブのためにWorkerを手動起動する手間をなくすため

動作確認
- VSCodeのDev: Allで3プロセスが別パネルで起動することを確認

close #156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VSCode task for running the backend Worker service.
  * Updated development task configuration to support running API and Worker concurrently.

* **Documentation**
  * Updated development guide with instructions for running API and Worker services together.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->