### PR TITLE
refactor: Firestore初期化からエミュレータ対応を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - 言語: Go 1.25 系
 - フレームワーク/主要ライブラリ: Gin、Google Cloud Firestore クライアント、Google Generative AI SDK、OpenAI クライアント、gRPC
 - アーキテクチャ: クリーンアーキテクチャ（Hexagonal 寄り）。API サーバーと非同期 Worker を分離し、usecase 層にビジネスロジックを集約し、外部依存は adapter/port で分離
-- データベース: Google Cloud Firestore（本番環境に接続。Emulator は未サポート）
+- データベース: Google Cloud Firestore（本番環境に接続）
 - デプロイ: Cloud Run でバックエンドプロセスをホスティング
 
 ## フロントエンド

--- a/backend/README.md
+++ b/backend/README.md
@@ -212,7 +212,6 @@ API / Worker から Firestore を利用する際は、`internal/app` が 1 度�
 | --- | --- |
 | `GOOGLE_CLOUD_PROJECT` | Firestore を利用する GCP / Firebase プロジェクト ID（必須） |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Firestore へ接続するサービスアカウント JSON のパス（必須） |
-| `FIRESTORE_EMULATOR_HOST` | Firestore Emulator を利用する場合のホスト名（Worker など開発用） |
 | `GEMINI_API_KEY` | Gemini formatter を使用する際の API キー |
 | `GEMINI_MODEL` | 利用する Gemini モデル名（未設定時は `gemini-2.5-flash`） |
 | `OPENAI_API_KEY` | OpenAI formatter を使用する際の API キー |
@@ -222,7 +221,7 @@ API / Worker から Firestore を利用する際は、`internal/app` が 1 度�
 
 `GOOGLE_CLOUD_PROJECT` / `GOOGLE_APPLICATION_CREDENTIALS` が未設定の場合、Infra の初期化が失敗し API / Worker は起動しません。Worker も API と同様に Firestore リポジトリ固定のため、必ず同じ環境変数を用意してください。JobQueue も Firestore 固定 (`format_jobs` コレクション) のため、切り替え用の環境変数は存在しません。
 
-### API を Firestore へ接続する（エミュレータ非対応）
+### API を Firestore へ接続する
 
 1. Firebase もしくは GCP で Firestore を有効化し、API から投稿を書き込むプロジェクト ID を決める。
 2. 対象プロジェクトでサービスアカウント（Cloud Datastore User 権限以上）を作成し、JSON キーをダウンロードする。
@@ -245,8 +244,6 @@ API / Worker から Firestore を利用する際は、`internal/app` が 1 度�
      -d '{"post_id":"post-123","content":"闇の投稿です"}'
    ```
 
-> API は Firestore Emulator をサポートしていません。常に本番と同じ Firestore（サービスアカウント JSON 経由）へ接続してください。
-
 ワーカーも同じ Firestore を共有します。Firestore 待ち受けが未設定のまま `go run ./cmd/worker` を起動した場合はエラーで即終了するため、API と同じく `GOOGLE_CLOUD_PROJECT` / `GOOGLE_APPLICATION_CREDENTIALS` を先に指定してください。
 
 ### コレクションスキーマ
@@ -263,11 +260,8 @@ API / Worker から Firestore を利用する際は、`internal/app` が 1 度�
 ```
 cd backend
 export GOOGLE_CLOUD_PROJECT=your-project
-# Firestore Emulator を使う場合は FIRESTORE_EMULATOR_HOST も設定
 go run ./cmd/seed
 ```
-
-エミュレータ利用時は `gcloud beta emulators firestore start --host-port=localhost:8080` を別ターミナルで起動してから実行してください。
 
 ## ワーカー起動方法
 

--- a/backend/internal/adapter/repository/firestore/post_repository.go
+++ b/backend/internal/adapter/repository/firestore/post_repository.go
@@ -31,17 +31,29 @@ type postDocument struct {
 	Status  string `firestore:"status"`
 }
 
+type postStore interface {
+	Create(ctx context.Context, doc postDocument) error
+	Get(ctx context.Context, id postdomain.DarkPostID) (postDocument, error)
+	ListReady(ctx context.Context, limit int) ([]postDocument, error)
+	Update(ctx context.Context, doc postDocument) error
+}
+
+type firestorePostStore struct {
+	client *firestore.Client
+}
+
 // PostRepository は Firestore を利用した Post リポジトリ実装。
 type PostRepository struct {
-	client *firestore.Client
+	store postStore
 }
 
 // NewPostRepository は Firestore クライアントを受け取って PostRepository を作成する。
 func NewPostRepository(client *firestore.Client) (*PostRepository, error) {
-	if client == nil {
-		return nil, errMissingClient
+	store, err := newFirestorePostStore(client)
+	if err != nil {
+		return nil, err
 	}
-	return &PostRepository{client: client}, nil
+	return &PostRepository{store: store}, nil
 }
 
 // Create は新しい Post を Firestore に保存する。
@@ -50,22 +62,12 @@ func (r *PostRepository) Create(ctx context.Context, p *postdomain.Post) error {
 		return errNilPost
 	}
 
-	doc := r.client.Collection(postsCollection).Doc(string(p.ID()))
-	data := map[string]any{
-		"post_id":    string(p.ID()),
-		"content":    string(p.Content()),
-		"status":     string(p.Status()),
-		"created_at": firestore.ServerTimestamp,
+	doc := postDocument{
+		PostID:  string(p.ID()),
+		Content: string(p.Content()),
+		Status:  string(p.Status()),
 	}
-
-	_, err := doc.Create(ctx, data)
-	if status.Code(err) == codes.AlreadyExists {
-		return repository.ErrPostAlreadyExists
-	}
-	if err != nil {
-		return fmt.Errorf("create post document: %w", err)
-	}
-	return nil
+	return r.store.Create(ctx, doc)
 }
 
 // Get は指定 ID の Post を Firestore から取得する。
@@ -74,45 +76,28 @@ func (r *PostRepository) Get(ctx context.Context, id postdomain.DarkPostID) (*po
 		return nil, repository.ErrPostNotFound
 	}
 
-	doc, err := r.client.Collection(postsCollection).Doc(string(id)).Get(ctx)
+	doc, err := r.store.Get(ctx, id)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, repository.ErrPostNotFound
-		}
-		return nil, fmt.Errorf("get post document: %w", err)
+		return nil, err
 	}
 
-	return restorePostFromDoc(doc)
+	return restorePostFromDocument(doc)
 }
 
 // ListReady は ready 状態の Post を最大 limit 件取得する。
 func (r *PostRepository) ListReady(ctx context.Context, limit int) ([]*postdomain.Post, error) {
-	query := r.client.Collection(postsCollection).
-		Where("status", "==", string(postdomain.StatusReady))
-	if limit > 0 {
-		query = query.Limit(limit)
+	documents, err := r.store.ListReady(ctx, limit)
+	if err != nil {
+		return nil, err
 	}
-
-	iter := query.Documents(ctx)
-	defer iter.Stop()
-
-	var posts []*postdomain.Post
-	for {
-		doc, err := iter.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("iterate ready posts: %w", err)
-		}
-
-		p, err := restorePostFromDoc(doc)
+	posts := make([]*postdomain.Post, 0, len(documents))
+	for _, doc := range documents {
+		p, err := restorePostFromDocument(doc)
 		if err != nil {
 			return nil, err
 		}
 		posts = append(posts, p)
 	}
-
 	return posts, nil
 }
 
@@ -125,30 +110,16 @@ func (r *PostRepository) Update(ctx context.Context, p *postdomain.Post) error {
 		return repository.ErrPostNotFound
 	}
 
-	doc := r.client.Collection(postsCollection).Doc(string(p.ID()))
-	updates := []firestore.Update{
-		{Path: "content", Value: string(p.Content())},
-		{Path: "status", Value: string(p.Status())},
-		{Path: "updated_at", Value: firestore.ServerTimestamp},
+	doc := postDocument{
+		PostID:  string(p.ID()),
+		Content: string(p.Content()),
+		Status:  string(p.Status()),
 	}
-
-	_, err := doc.Update(ctx, updates)
-	if status.Code(err) == codes.NotFound {
-		return repository.ErrPostNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("update post document: %w", err)
-	}
-	return nil
+	return r.store.Update(ctx, doc)
 }
 
-// restorePostFromDoc は Firestore ドキュメントから Post ドメインを復元する。
-func restorePostFromDoc(doc *firestore.DocumentSnapshot) (*postdomain.Post, error) {
-	var payload postDocument
-	if err := doc.DataTo(&payload); err != nil {
-		return nil, fmt.Errorf("decode post document: %w", err)
-	}
-
+// restorePostFromDocument は Post の保存データからドメインを復元する。
+func restorePostFromDocument(payload postDocument) (*postdomain.Post, error) {
 	post, err := postdomain.Restore(
 		postdomain.DarkPostID(payload.PostID),
 		postdomain.DarkContent(payload.Content),
@@ -158,4 +129,90 @@ func restorePostFromDoc(doc *firestore.DocumentSnapshot) (*postdomain.Post, erro
 		return nil, fmt.Errorf("restore post: %w", err)
 	}
 	return post, nil
+}
+
+func newFirestorePostStore(client *firestore.Client) (*firestorePostStore, error) {
+	if client == nil {
+		return nil, errMissingClient
+	}
+	return &firestorePostStore{client: client}, nil
+}
+
+func (s *firestorePostStore) Create(ctx context.Context, doc postDocument) error {
+	ref := s.client.Collection(postsCollection).Doc(doc.PostID)
+	data := map[string]any{
+		"post_id":    doc.PostID,
+		"content":    doc.Content,
+		"status":     doc.Status,
+		"created_at": firestore.ServerTimestamp,
+	}
+	_, err := ref.Create(ctx, data)
+	if status.Code(err) == codes.AlreadyExists {
+		return repository.ErrPostAlreadyExists
+	}
+	if err != nil {
+		return fmt.Errorf("create post document: %w", err)
+	}
+	return nil
+}
+
+func (s *firestorePostStore) Get(ctx context.Context, id postdomain.DarkPostID) (postDocument, error) {
+	doc, err := s.client.Collection(postsCollection).Doc(string(id)).Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return postDocument{}, repository.ErrPostNotFound
+		}
+		return postDocument{}, fmt.Errorf("get post document: %w", err)
+	}
+	var payload postDocument
+	if err := doc.DataTo(&payload); err != nil {
+		return postDocument{}, fmt.Errorf("decode post document: %w", err)
+	}
+	return payload, nil
+}
+
+func (s *firestorePostStore) ListReady(ctx context.Context, limit int) ([]postDocument, error) {
+	query := s.client.Collection(postsCollection).
+		Where("status", "==", string(postdomain.StatusReady))
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	iter := query.Documents(ctx)
+	defer iter.Stop()
+
+	var documents []postDocument
+	for {
+		doc, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("iterate ready posts: %w", err)
+		}
+		var payload postDocument
+		if err := doc.DataTo(&payload); err != nil {
+			return nil, fmt.Errorf("decode post document: %w", err)
+		}
+		documents = append(documents, payload)
+	}
+	return documents, nil
+}
+
+func (s *firestorePostStore) Update(ctx context.Context, doc postDocument) error {
+	ref := s.client.Collection(postsCollection).Doc(doc.PostID)
+	updates := []firestore.Update{
+		{Path: "content", Value: doc.Content},
+		{Path: "status", Value: doc.Status},
+		{Path: "updated_at", Value: firestore.ServerTimestamp},
+	}
+
+	_, err := ref.Update(ctx, updates)
+	if status.Code(err) == codes.NotFound {
+		return repository.ErrPostNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("update post document: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
変更内容: firestore.go から FIRESTORE_EMULATOR_HOST の参照と Emulator 用の認証分岐を削除し、GOOGLE_APPLICATION_CREDENTIALS 指定時は常に WithCredentialsJSON で初期化するよう整理

なぜ: プロジェクト方針を「ローカルも本番Firestore直結」に統一するため

備考: テスト/README 側の FIRESTORE_EMULATOR_HOST 記述は別sub issueで対応予定

close #171 