### PR TITLE
feat: 投稿後に結果を表示

### DIFF
--- a/frontend/src/components/pages/home.tsx
+++ b/frontend/src/components/pages/home.tsx
@@ -11,6 +11,8 @@ export default function HomePage() {
   const [content, setContent] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [resultText, setResultText] = useState("");
+  const defaultPostError = "投稿に失敗しました";
+  const defaultDrawError = "おみくじの取得に失敗しました";
   const contentLength = content.length;
   const trimmedLength = content.trim().length;
   const isSubmitDisabled = trimmedLength === 0 || contentLength > 140;
@@ -36,12 +38,21 @@ export default function HomePage() {
     setErrorMessage("");
     try {
       await createPost(content.trim());
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : defaultPostError,
+      );
+      setCurrentStep("error");
+      return;
+    }
+
+    try {
       const draw = await fetchRandomDraw();
       setResultText(draw.result);
       setCurrentStep("result");
     } catch (error) {
       setErrorMessage(
-        error instanceof Error ? error.message : "投稿に失敗しました",
+        error instanceof Error ? error.message : defaultDrawError,
       );
       setCurrentStep("error");
     }


### PR DESCRIPTION
## What
- 投稿成功後に fetchRandomDraw を呼び出して取得した result を結果画面へ表示
- 投稿失敗とおみくじ取得失敗時のエラーメッセージを出し分け、リトライ操作の挙動を整理

close #162