### PR TITLE
fix: Firestore ポーリング間隔をバックオフ対応に調整

### DIFF
--- a/backend/internal/adapter/queue/firestore/job_queue.go
+++ b/backend/internal/adapter/queue/firestore/job_queue.go
@@ -96,7 +96,6 @@ func (q *FirestoreJobQueue) DequeueFormat(ctx context.Context) (post.DarkPostID,
 		}
 		id, err := q.dequeueOnce(ctx)
 		if err == nil {
-			waitInterval = pollIntervalMin
 			return id, nil
 		}
 		// ジョブがまだ用意されていない場合は停止指示を監視しながら待機して再試行する


### PR DESCRIPTION
## What
- Firestore ジョブキューのポーリングを指数バックオフ対応に変更
- 最小3分〜最大5分の待機間隔で空振り時のトランザクション連打を抑制

close #181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Job queue polling now uses an adaptive exponential backoff strategy, reducing needless polling and resource use while recovering promptly when work appears. This improves efficiency and stability of job processing cycles without changing external behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->