### PR TITLE
fix: APIベースURL末尾のスラッシュを正規化

### DIFF
--- a/frontend/src/lib/posts.ts
+++ b/frontend/src/lib/posts.ts
@@ -9,6 +9,9 @@ export type CreatePostResponse = {
   post_id: string;
 };
 
+// APIのベースURLの末尾のスラッシュを取り除く。
+const normalizeApiBaseUrl = () => getApiBaseUrl().replace(/\/+$/, "");
+
 /**
  * 闇投稿を登録する。
  */
@@ -22,7 +25,7 @@ export const createPost = async (content: string) => {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), 10_000);
 
-  const response = await fetch(`${getApiBaseUrl()}/posts`, {
+  const response = await fetch(`${normalizeApiBaseUrl()}/posts`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## What

- 投稿APIの呼び出し前にAPIベースURL末尾のスラッシュを除去
- //posts のような二重スラッシュを防止

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API URL handling to prevent connection issues caused by trailing slashes in the base URL, ensuring more reliable API communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->