### PR TITLE
chore: PRタイトル検証ジョブを無効化

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
+    if: false
     runs-on: ubuntu-slim
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1


### PR DESCRIPTION
## What
- PRタイトル検証ワークフローのジョブを常にスキップする設定にしました。
- PR作成時にタイトルlintが走らないようにしています。

## Why
- タイトル検証が不要になったため、運用コストを下げるためです。
- 既存の設定は残しつつ動作だけ止める方針にしました。

close #234 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.

---

**Note:** This release contains no user-visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->