### PR TITLE
chore: PRタイトルlintをpull_requestで実行

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -1,7 +1,7 @@
 name: "Lint Pull Request Titles"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
## What
- PRタイトルlintのトリガーを pull_request_target から pull_request に変更しました。

## Why
- main側のワークフロー実行を避け、PR側のワークフローだけ動かすためです。

close #236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve pull request processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->