### PR TITLE
refactor: cmd/api をrun関数に分割

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -30,7 +30,7 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("依存初期化失敗: %w", err)
 	}
-	
+
 	// 関数の終了時に依存リソースを閉じる
 	defer func() {
 		if closeErr := container.Close(); closeErr != nil {


### PR DESCRIPTION
## What
- cmd/api の main を run() に分割し、起動処理を切り出し
- main に起動コメント、run に初期化・起動コメントを追加

## Why
- cmd/api の起動経路をテスト可能にするため
- 入口と本体の責務を分離して見通しを良くするため

close #245 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and logging during API startup.
  * Enhanced resource cleanup and initialization flow with better error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->